### PR TITLE
Cow 94/api/chore/d bexpansion

### DIFF
--- a/apps/api/coworks/coworkService.ts
+++ b/apps/api/coworks/coworkService.ts
@@ -9,11 +9,13 @@ export default class CoworkService {
   static async createCowork(data: CreateCoworkInput): Promise<Cowork> {
     try {
       const parsedData = CoworkValidate.validateCreate(data)
+      const superAdmin = await this._client.superAdmin.findFirst() // TODO: Change with superadmin auth name
       return await this._client.cowork.create({
         data: {
           email: parsedData.email,
           name: parsedData.name,
           phone: parsedData.phone,
+          updatedBy: superAdmin.name,
           address: {
             create: {
               apartment: parsedData.address?.apartment,
@@ -72,10 +74,24 @@ export default class CoworkService {
           phone: parsedData.phone,
           address: {
             update: { ...parsedData.address }
+          },
+          amenities: {
+            upsert: {
+              update: { ...parsedData.amenities },
+              create: { ...parsedData.amenities }
+            }
+          },
+          openSchedule: {
+            upsert: {
+              update: { ...parsedData.openSchedule },
+              create: { ...parsedData.openSchedule }
+            }
           }
         },
         include: {
-          address: true
+          address: true,
+          openSchedule: true,
+          amenities: true
         }
       })
     } catch (err) {

--- a/apps/api/coworks/coworkValidation.ts
+++ b/apps/api/coworks/coworkValidation.ts
@@ -21,6 +21,26 @@ export default class CoworkValidate {
     email: z.string().email().optional(),
     name: z.string().optional(),
     phone: z.string().optional(),
+    description: z.string().optional(),
+    status: z.enum(['ACTIVE', 'PAUSED', 'CLOSED']).optional(),
+    amenities: z
+      .object({
+        wifi: z.boolean().optional(),
+        bathrooms: z.number().optional(),
+        buffet: z.boolean().optional()
+      })
+      .optional(),
+    openSchedule: z
+      .object({
+        mon: z.string().optional(),
+        tue: z.string().optional(),
+        wed: z.string().optional(),
+        thu: z.string().optional(),
+        fri: z.string().optional(),
+        sat: z.string().optional(),
+        sun: z.string().optional()
+      })
+      .optional(),
     address: z
       .object({
         country: z.string().optional(),

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -12,11 +12,10 @@ datasource db {
 }
 
 model SuperAdmin {
-  id            String   @id @unique @default(cuid())
-  name          String?
-  mail          String   @unique
-  token         String?
-  editedCoworks Cowork[]
+  id    String  @id @unique @default(cuid())
+  name  String?
+  mail  String  @unique
+  token String?
 }
 
 enum Role {
@@ -83,35 +82,33 @@ model OpenSchedule {
 // TODO: expand / check specificity
 model CoworkAmenities {
   id        String   @id @unique @default(cuid())
-  wifi      Boolean
-  bathrooms Int
-  buffet    Boolean
+  wifi      Boolean?
+  bathrooms Int?
+  buffet    Boolean?
   Cowork    Cowork[]
 }
 
 model Cowork {
-  id             String          @id @unique @default(cuid())
-  address        Address         @relation(fields: [addressId], references: [id])
-  addressId      String          @unique
-  name           String          @unique
+  id             String           @id @unique @default(cuid())
+  address        Address          @relation(fields: [addressId], references: [id])
+  addressId      String           @unique
+  name           String           @unique
   email          String?
-  description    String
-  status         Status          @default(ACTIVE)
+  description    String?
+  status         Status           @default(ACTIVE)
   phone          String?
-  openSchedule   OpenSchedule?   @relation(fields: [openScheduleId], references: [id])
-  amenities      CoworkAmenities @relation(fields: [amenitiesId], references: [id])
-  rating         Float           @default(0.0)
+  openSchedule   OpenSchedule?    @relation(fields: [openScheduleId], references: [id])
+  amenities      CoworkAmenities? @relation(fields: [amenitiesId], references: [id])
+  rating         Float            @default(0.0)
   Space          Space[]
   Review         Review[]
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
-  updatedBy      SuperAdmin      @relation(fields: [superAdminId], references: [id])
-  superAdminId   String
-  openScheduleId String?         @unique
-  amenitiesId    String          @unique
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
+  updatedBy      String
+  openScheduleId String?          @unique
+  amenitiesId    String           @unique
 
   @@index([addressId])
-  @@index([superAdminId])
   @@index([openScheduleId])
   @@index([amenitiesId])
 }

--- a/apps/api/users/userService.ts
+++ b/apps/api/users/userService.ts
@@ -66,7 +66,7 @@ export default class UserService {
         html: loginTemplate(
           `${user.firstName} ${user.lastName}`,
           userJWT,
-          user.rol
+          user.role
         )
       })
       return true


### PR DESCRIPTION
Changes:

-  rename user field 'rol' to 'role'

Additions:

-> Added following fields to Coworks:

- description
- status
- openSchedule (string for each day of thw week -> we should set a format standard)
- amenities (to expand)
- createdAt
- updatedAt
- updatedBy (not yet fully implemented -> blocked by COW-63)

-> Added amenities to Space (to expand)

Resolved:
- Company / admin will not be a direct relation in the DB structure. This will facilitate the possibility of having multiple admins for one company. In order to get Company admins we should add an 
```include :  { employees:  {  where: { role: ADMIN } } }  ```  in the company queries.