### PR TITLE
feat/refactor: add absolute pagination

### DIFF
--- a/apps/api/coworks/coworkController.ts
+++ b/apps/api/coworks/coworkController.ts
@@ -39,11 +39,13 @@ export default class CoworkController {
     @Query('country') country?: string,
     @Query('sort') sort?: string,
     @Query('count') count?: number,
-    @Query('cursor') cursor?: string
+    @Query('cursor') cursor?: string,
+    @Query('page') page?: number
   ) {
     return CoworkService.fetchAll({ status, city, country }, sort, {
       count,
-      cursor
+      cursor,
+      page
     })
   }
 

--- a/apps/api/coworks/coworkRouter.ts
+++ b/apps/api/coworks/coworkRouter.ts
@@ -7,14 +7,15 @@ const coworkRoutes = Router()
 
 coworkRoutes.get('/', async (req, res, next) => {
   try {
-    const { status, city, country, sort, count, cursor } = req.query
+    const { status, city, country, sort, count, cursor, page } = req.query
     const response = await CoworkController.getCoworks(
       status?.toString() as CoworkFilters['status'],
       city?.toString(),
       country?.toString(),
       sort?.toString(),
       count ? parseInt(count.toString()) : undefined,
-      cursor?.toString()
+      cursor?.toString(),
+      page ? parseInt(page.toString()) : undefined
     )
     res.send(response)
   } catch (err) {

--- a/apps/api/public/swagger.json
+++ b/apps/api/public/swagger.json
@@ -327,6 +327,12 @@
 			},
 			"PaginatedResponse_CoworkFull-Array_": {
 				"properties": {
+					"totalPages": {
+						"type": "string"
+					},
+					"page": {
+						"type": "string"
+					},
 					"cursor": {
 						"type": "string"
 					},
@@ -338,7 +344,6 @@
 					}
 				},
 				"required": [
-					"cursor",
 					"results"
 				],
 				"type": "object"
@@ -767,7 +772,7 @@
 				"operationId": "GetCoworks",
 				"responses": {
 					"200": {
-						"description": "PaginatedResponse<CoworkFull[]>",
+						"description": "PaginatedCoworks",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -830,6 +835,15 @@
 						"required": false,
 						"schema": {
 							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "page",
+						"required": false,
+						"schema": {
+							"format": "double",
+							"type": "number"
 						}
 					}
 				]

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -46,7 +46,9 @@ export interface Cowork {
 
 export type PaginatedResponse<T> = {
   results: T
-  cursor: string
+  cursor?: string
+  page?: string
+  totalPages?: string
 }
 
 export type CoworkCreateReq = CreateCoworkInput


### PR DESCRIPTION
- Add new pagination mode:

  - If request has query param 'page' set to truthy value (number expected) it will return the ammount of coworks required and an index of total pages (page: currentPage, totalPages: ...)

  - If no page attribute is present it will return a cursor just like the previous implementation.

     *All of these attributes are optional.*

- Changed PaginatedResponse type accordingly.