### PR TITLE
Cow 120/front/feat/api error handler

### DIFF
--- a/apps/api/coworks/cowork.test.ts
+++ b/apps/api/coworks/cowork.test.ts
@@ -25,6 +25,7 @@ const mockCowork: CoworkFull = {
   amenities: null,
   amenitiesId: '',
   status: 'ACTIVE',
+  image: '',
   name: 'test cowork. com',
   email: 'test@test.com',
   description: 'shamalayan test',

--- a/apps/api/coworks/cowork.test.ts
+++ b/apps/api/coworks/cowork.test.ts
@@ -4,9 +4,6 @@ import CoworkService from './coworkService'
 import { Address } from '@prisma/client'
 import { CoworkFull } from './coworkTypes'
 import CustomError from '../errors/customError'
-import { ErrorInterface } from '../errors/errorInterface'
-import Auth from '../middleware/auth.middleware'
-import { Request, Response, NextFunction } from 'express'
 
 const mockAddress: Address = {
   id: '',
@@ -25,7 +22,7 @@ const mockCowork: CoworkFull = {
   amenities: null,
   amenitiesId: '',
   status: 'ACTIVE',
-  image: '',
+  image: 'google.com/image1.jpg',
   name: 'test cowork. com',
   email: 'test@test.com',
   description: 'shamalayan test',

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -115,6 +115,7 @@ model Cowork {
   email          String
   description    String
   status         Status           @default(ACTIVE)
+  image          String           @default("") @db.VarChar(1000)
   phone          String
   openSchedule   OpenSchedule?    @relation(fields: [openScheduleId], references: [id])
   amenities      CoworkAmenities? @relation(fields: [amenitiesId], references: [id])

--- a/apps/api/public/swagger.json
+++ b/apps/api/public/swagger.json
@@ -213,6 +213,9 @@
 					"phone": {
 						"type": "string"
 					},
+					"image": {
+						"type": "string"
+					},
 					"status": {
 						"$ref": "#/components/schemas/Status"
 					},
@@ -240,6 +243,7 @@
 					"createdAt",
 					"rating",
 					"phone",
+					"image",
 					"status",
 					"description",
 					"email",

--- a/apps/api/users/userRouter.ts
+++ b/apps/api/users/userRouter.ts
@@ -39,7 +39,8 @@ userRoutes.post(
 userRoutes.post('/auth', async (req, res, next) => {
   try {
     const response = await UserController.auth(req.body.id, req.body.token)
-    return res.send(response)
+    if (response) return res.send(response)
+    res.sendStatus(401)
   } catch (err) {
     next(err)
   }

--- a/apps/front/modules/auth/components/LoginForm.tsx
+++ b/apps/front/modules/auth/components/LoginForm.tsx
@@ -2,6 +2,7 @@ import Axios from '@/common/utils/axios'
 import { AxiosError } from 'axios'
 import { useState } from 'react'
 import { toast } from 'sonner'
+import { useRouter } from 'next/router'
 
 const STATUS = {
   loading: 'loading',
@@ -18,6 +19,9 @@ export const LoginForm = ({ endpoint }: { endpoint: string }) => {
   const [btnMessage, setBtnMessage] = useState<string>('Sign in')
 
   const api = Axios.getInstance()
+
+  const router = useRouter()
+  const { token_error } = router.query
 
   const formSubmitHandler = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -54,6 +58,9 @@ export const LoginForm = ({ endpoint }: { endpoint: string }) => {
   return (
     <section className="mx-auto flex  w-full flex-col items-center justify-center px-6 py-8 lg:py-0">
       <div className="w-full rounded-lg bg-white shadow sm:max-w-md md:mt-0 xl:p-0">
+        {!!token_error &&
+          <p className='pt-6 text-center font-bold text-red-400'>{token_error}</p>
+        }
         <div className="space-y-4 p-6 sm:p-8 md:space-y-6">
           <form
             className="space-y-4 md:space-y-6"

--- a/apps/front/modules/auth/components/LoginForm.tsx
+++ b/apps/front/modules/auth/components/LoginForm.tsx
@@ -2,7 +2,7 @@ import Axios from '@/common/utils/axios'
 import { AxiosError } from 'axios'
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { useRouter } from 'next/router'
+import { useSearchParams } from 'next/navigation'
 
 const STATUS = {
   loading: 'loading',
@@ -20,8 +20,7 @@ export const LoginForm = ({ endpoint }: { endpoint: string }) => {
 
   const api = Axios.getInstance()
 
-  const router = useRouter()
-  const { token_error } = router.query
+  const token_error = useSearchParams()?.get('token_error')
 
   const formSubmitHandler = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()

--- a/apps/front/modules/auth/utils/errorMessages.ts
+++ b/apps/front/modules/auth/utils/errorMessages.ts
@@ -1,0 +1,2 @@
+export const TOKEN_IVALID =
+  'Token is expired or non-valid. Try sending new email'

--- a/apps/front/pages/api/superadmin/index.ts
+++ b/apps/front/pages/api/superadmin/index.ts
@@ -3,6 +3,7 @@ import jwt_decode from 'jwt-decode'
 
 import { withSessionRoute } from '@/modules/auth/utils/withSession'
 import { SuperAdminData } from 'types'
+import { TOKEN_IVALID } from '@/modules/auth/utils/errorMessages'
 
 export default withSessionRoute(login)
 
@@ -24,18 +25,17 @@ async function login(req: NextApiRequest, res: NextApiResponse) {
       }
     )
 
-    // TODO: Implement better error handling
-    // 1. Invalid token
-    // 2. Token already used
-
-    const isAuthOk = (await response.status) === 200
+    const isAuthOk = response.status === 200
 
     if (isAuthOk) {
-      req.session.superadmin = { ...superAdminData, access_token }
+      req.session.superadmin = {
+        ...superAdminData,
+        access_token
+      }
       await req.session.save()
       return res.redirect('/superadmin/coworks')
     }
-    return res.redirect('/superadmin')
+    return res.redirect(`/superadmin?token_error=${TOKEN_IVALID}`)
   } catch (err) {
     res.status(500).json(err)
   }


### PR DESCRIPTION
# :bell: Frontend API routes error handling & fix

- Agregué un mensaje encima del formulario de email diciendo que el token no anduvo y proponiendo mandar un nuevo email
- El dato de que falló se pasa por query param a la ruta de login

&nbsp;

## :question::question::question::question:

- Queda algún caso de error en especial por señalar diferente?
- Revisar estilos
- Pasar la notificacion a un toast?

&nbsp;

## :pushpin: Notes:

- En las funciones de servidor mejor usar directamente el fetch. Axios estaba usando data de sesión (creo) por lo que la función de login no tenía en cuenta la respuesta del servidor y logeaba de todos modos.

&nbsp;
