### PR TITLE
fix: remove overwrite of schedule data on form

### DIFF
--- a/apps/front/modules/coworks/components/EditCoworkForm.tsx
+++ b/apps/front/modules/coworks/components/EditCoworkForm.tsx
@@ -26,16 +26,7 @@ export const EditCoworkForm = ({ data }: CoworkFormProps) => {
     formState: { errors }
   } = useForm({
     defaultValues: {
-      ...data,
-      openSchedule: {
-        mon: '',
-        tue: '',
-        wed: '',
-        thu: '',
-        fri: '',
-        sat: '',
-        sun: ''
-      }
+      ...data
     }
   })
 


### PR DESCRIPTION
# :bell: Fix superadmin form

- Se estaba reescribiendo la data del openSchedule con valores nulos por defecto.

&nbsp;

# ❓ ❓ ❓ 

- Convendra guardar esta data de otra forma?

